### PR TITLE
Fix code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,8 @@
     "express-async-handler": "^1.2.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.5.3",
-    "typescript": ">=4.9.3 and <5.2.0"
+    "typescript": ">=4.9.3 and <5.2.0",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.4",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,7 @@ dotenv.config()
 import path from 'path'
 import express from 'express'
 import cors from 'cors'
+import rateLimit from 'express-rate-limit'
 const food_routes = require('./routes/food.routes')
 const user_routes = require('./routes/user.routes')
 const order_routes = require('./routes/order.routes')
@@ -13,12 +14,18 @@ dbConnect()
 
 const app = express()
 
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
 app.use(express.json())
 app.use(cors({
     credentials: true,
     origin: ['http://localhost:4200']
 }))
 
+app.use(limiter);
 app.use('/api/foods', food_routes)
 app.use('/api/users', user_routes)
 app.use('/api/orders', order_routes)


### PR DESCRIPTION
Fixes [https://github.com/indervirsingh/ExpressDonut/security/code-scanning/2](https://github.com/indervirsingh/ExpressDonut/security/code-scanning/2)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make to the server within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `backend/src/server.ts` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to all routes or specifically to the route serving the static file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
